### PR TITLE
hide answer form for the indecis

### DIFF
--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -67,6 +67,9 @@
       <% end %>
     </div>
     <% hide_answer_creation = false %>
+    <% if current_user == @question.user %>
+        <% hide_answer_creation = true %>
+    <% end %>
     <% @question.answers.each do |answer| %>
       <% if answer.user == current_user %>
         <% hide_answer_creation = true %>


### PR DESCRIPTION
@off-batt : j'ai caché le formulaire de réponse, mais en revanche le titre apparait pour le moment : à voir quelle expérience on propose en attente de réponse : cf. le sujet plus global de la refonte de l'ux sur les écrans d'indécision